### PR TITLE
Respect disabled IPv6 setting for leak protection

### DIFF
--- a/proton/vpn/connection/states.py
+++ b/proton/vpn/connection/states.py
@@ -300,7 +300,10 @@ class Connected(State):
 
     async def run_tasks(self):
         if self.context.kill_switch_setting == KillSwitchSetting.OFF:
-            await self.context.kill_switch.enable_ipv6_leak_protection()
+            if self.context.connection.settings.ipv6:
+                await self.context.kill_switch.enable_ipv6_leak_protection()
+            else:
+                await self.context.kill_switch.disable_ipv6_leak_protection()
             await self.context.kill_switch.disable()
             if self.context.split_tunneling_setting.enabled:
                 try:

--- a/proton/vpn/core/connection.py
+++ b/proton/vpn/core/connection.py
@@ -208,7 +208,10 @@ class VPNConnector:  # pylint: disable=too-many-instance-attributes
                 await kill_switch.disable()
                 await kill_switch.disable_ipv6_leak_protection()
             else:
-                await kill_switch.enable_ipv6_leak_protection()
+                if self.current_connection and self.current_connection.settings.ipv6:
+                    await kill_switch.enable_ipv6_leak_protection()
+                else:
+                    await kill_switch.disable_ipv6_leak_protection()
                 await kill_switch.disable()
 
         else:

--- a/proton/vpn/core/connection.py
+++ b/proton/vpn/core/connection.py
@@ -174,7 +174,7 @@ class VPNConnector:  # pylint: disable=too-many-instance-attributes
         ks_setting = KillSwitchSetting(settings.killswitch)
         protocol = settings.protocol
         self._set_ks_setting(ks_setting, protocol)
-        await self._apply_kill_switch_setting(ks_setting)
+        await self._apply_kill_switch_setting(ks_setting, settings)
 
         if self.current_connection:
             await self.current_connection.update_settings(settings)
@@ -185,7 +185,9 @@ class VPNConnector:  # pylint: disable=too-many-instance-attributes
         if self.is_split_tunneling_available and self.is_connected:
             await self._apply_split_tunneling_settings(st_setting, ks_setting)
 
-    async def _apply_kill_switch_setting(self, kill_switch_setting: KillSwitchSetting):
+    async def _apply_kill_switch_setting(
+            self, kill_switch_setting: KillSwitchSetting, settings: Settings = None
+    ):
         """Enables/disables the kill switch depending on the setting value."""
         kill_switch = self._current_state.context.kill_switch
 
@@ -208,7 +210,10 @@ class VPNConnector:  # pylint: disable=too-many-instance-attributes
                 await kill_switch.disable()
                 await kill_switch.disable_ipv6_leak_protection()
             else:
-                if self.current_connection and self.current_connection.settings.ipv6:
+                ipv6_enabled = settings.ipv6 if settings else (
+                    self.current_connection and self.current_connection.settings.ipv6
+                )
+                if ipv6_enabled:
                     await kill_switch.enable_ipv6_leak_protection()
                 else:
                     await kill_switch.disable_ipv6_leak_protection()

--- a/tests/connection/test_states.py
+++ b/tests/connection/test_states.py
@@ -379,6 +379,7 @@ async def test_disconnecting_run_tasks_stops_connection():
 async def test_connected_run_tasks_swallows_split_tunneling_errors():
     connection = Mock()
     connection.add_persistence = AsyncMock()
+    connection.settings = Mock(ipv6=True)
     context = states.StateContext(connection=connection)
     context.kill_switch = AsyncMock()
     context.kill_switch_setting = KillSwitchSetting.OFF
@@ -391,6 +392,28 @@ async def test_connected_run_tasks_swallows_split_tunneling_errors():
 
     # The split tunneling exception shouldn't have bubbled up when applying ST config
     context.split_tunneling.set_config.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_connected_run_tasks_disables_ipv6_leak_protection_when_connection_ipv6_is_disabled():
+    connection = Mock()
+    connection.add_persistence = AsyncMock()
+    connection.settings = Mock(ipv6=False)
+    context = states.StateContext(connection=connection)
+    context.kill_switch = AsyncMock()
+    context.kill_switch_setting = KillSwitchSetting.OFF
+    context.split_tunneling = AsyncMock()
+    context.split_tunneling_setting = SplitTunnelingSetting(enabled=True)
+    connected = states.Connected(context)
+
+    await connected.run_tasks()
+
+    context.kill_switch.disable_ipv6_leak_protection.assert_called_once()
+    context.kill_switch.disable.assert_called_once()
+    context.split_tunneling.set_config.assert_called_once_with(
+        context.split_tunneling_setting.get_config()
+    )
+    connection.add_persistence.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_connection.py
+++ b/tests/core/test_connection.py
@@ -21,7 +21,8 @@ from proton.vpn.session.servers import LogicalServer
 from proton.vpn.session.client_config import ClientConfig
 from proton.vpn.core.connection import VPNConnector
 from proton.vpn.connection import events, exceptions, states
-from unittest.mock import Mock, AsyncMock
+from proton.vpn.connection.enum import KillSwitchSetting
+from unittest.mock import Mock, AsyncMock, call
 import pytest
 
 
@@ -284,3 +285,24 @@ async def test_connector_updates_connection_credentials_when_certificate_is_refr
 
     if update_credentials_expected:
         current_state.context.connection.update_credentials.assert_called_once_with(session_holder.vpn_credentials)
+
+
+@pytest.mark.asyncio
+async def test_apply_kill_switch_setting_disables_ipv6_leak_protection_when_connection_ipv6_is_disabled():
+    connection = Mock()
+    connection.settings = Mock(ipv6=False)
+    state = states.Connected(states.StateContext(connection=connection))
+    state.context.kill_switch = AsyncMock()
+    connector = VPNConnector(
+        session_holder=None,
+        settings_persistence=None,
+        usage_reporting=Mock(),
+        state=state,
+    )
+
+    await connector._apply_kill_switch_setting(KillSwitchSetting.OFF)
+
+    assert state.context.kill_switch.method_calls == [
+        call.disable_ipv6_leak_protection(),
+        call.disable(),
+    ]

--- a/tests/core/test_connection.py
+++ b/tests/core/test_connection.py
@@ -306,3 +306,35 @@ async def test_apply_kill_switch_setting_disables_ipv6_leak_protection_when_conn
         call.disable_ipv6_leak_protection(),
         call.disable(),
     ]
+
+
+@pytest.mark.asyncio
+async def test_apply_settings_disables_ipv6_leak_protection_when_ipv6_is_turned_off_while_connected():
+    connection = Mock()
+    connection.settings = Mock(ipv6=True)
+    connection.update_settings = AsyncMock(
+        side_effect=lambda settings: setattr(connection, "settings", settings)
+    )
+    state = states.Connected(states.StateContext(connection=connection))
+    state.context.kill_switch = AsyncMock()
+
+    connector = VPNConnector(
+        session_holder=None,
+        settings_persistence=None,
+        usage_reporting=Mock(),
+        state=state,
+    )
+    connector._split_tunneling = None
+
+    settings = Mock()
+    settings.killswitch = KillSwitchSetting.OFF.value
+    settings.protocol = "wireguard"
+    settings.ipv6 = False
+    settings.features = Mock(split_tunneling=Mock(enabled=False))
+
+    await connector.apply_settings(settings)
+
+    assert state.context.kill_switch.method_calls == [
+        call.disable_ipv6_leak_protection(),
+        call.disable(),
+    ]


### PR DESCRIPTION
This fixes an IPv6 leak-protection mismatch when the user has disabled IPv6 in Proton VPN settings.

Today the connector still enables IPv6 leak protection whenever kill switch is off, even if `settings.ipv6` is `false`. On Linux/NetworkManager that can leave `pvpn-killswitch-ipv6` active and change IPv6 routing/DNS even though IPv6 support was explicitly disabled in the app settings.

This patch makes both call sites respect the connection setting:
- `Connected.run_tasks()`
- `VPNConnector._apply_kill_switch_setting()`

It also adds focused regression tests for the connect-time path and the apply-settings path.

Tested locally with:
- `pytest -q -o addopts= tests/connection/test_states.py tests/core/test_connection.py`