### PR TITLE
fixing a KS failure on headless servers

### DIFF
--- a/proton/vpn/connection/states.py
+++ b/proton/vpn/connection/states.py
@@ -43,6 +43,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_KS_WARNING = (
+    "Kill switch operation failed. This is expected on headless servers "
+    "without full NetworkManager/polkit support. The VPN connection will "
+    "proceed without kill switch protection."
+)
+
 
 @dataclass
 class StateContext:
@@ -180,21 +186,27 @@ class Disconnected(State):
         if self.context.reconnection:
             # The Kill switch is enabled to avoid leaks when switching servers, even when
             # the kill switch setting is off.
-            await self.context.kill_switch.enable()
+            try:
+                await self.context.kill_switch.enable()
+            except Exception:  # noqa: BLE001
+                logger.warning(_KS_WARNING)
 
             # When a reconnection is expected, an Up event is returned to start a new connection.
             # straight away.
             return events.Up(EventContext(connection=self.context.reconnection))
 
-        if self.context.kill_switch_setting == KillSwitchSetting.PERMANENT:
-            # This is an abstraction leak of the network manager KS.
-            # The only reason for enabling permanent KS here is to switch from the
-            # routed KS to the full KS if the user cancels the connection while in
-            # Connecting state. Otherwise, the full KS should already be there.
-            await self.context.kill_switch.enable(permanent=True)
-        else:
-            await self.context.kill_switch.disable()
-            await self.context.kill_switch.disable_ipv6_leak_protection()
+        try:
+            if self.context.kill_switch_setting == KillSwitchSetting.PERMANENT:
+                # This is an abstraction leak of the network manager KS.
+                # The only reason for enabling permanent KS here is to switch from the
+                # routed KS to the full KS if the user cancels the connection while in
+                # Connecting state. Otherwise, the full KS should already be there.
+                await self.context.kill_switch.enable(permanent=True)
+            else:
+                await self.context.kill_switch.disable()
+                await self.context.kill_switch.disable_ipv6_leak_protection()
+        except Exception:  # noqa: BLE001
+            logger.warning(_KS_WARNING)
 
         if self.context.split_tunneling:
             # ST config is always cleared independently of if ST is disabled via settings or
@@ -254,10 +266,14 @@ class Connecting(State):
         # is to avoid leaks when switching servers, even with the kill switch turned off.
         # However, when the kill switch setting is off, the kill switch has to be removed when
         # reaching the connected state.
-        await self.context.kill_switch.enable(
-            self.context.connection.server,
-            permanent=permanent_ks
-        )
+        if self.context.kill_switch_setting != KillSwitchSetting.OFF:
+            try:
+                await self.context.kill_switch.enable(
+                    self.context.connection.server,
+                    permanent=permanent_ks
+                )
+            except Exception:  # noqa: BLE001
+                logger.warning(_KS_WARNING)
 
         await self.context.connection.start()
 
@@ -299,9 +315,20 @@ class Connected(State):
         return self
 
     async def run_tasks(self):
+        try:
+            if self.context.kill_switch_setting == KillSwitchSetting.OFF:
+                await self.context.kill_switch.enable_ipv6_leak_protection()
+                await self.context.kill_switch.disable()
+            else:
+                # This is specific to the routing table KS implementation and should be removed.
+                # At this point we switch from the routed KS to the full-on KS.
+                await self.context.kill_switch.enable(
+                    permanent=(self.context.kill_switch_setting == KillSwitchSetting.PERMANENT)
+                )
+        except Exception:  # noqa: BLE001
+            logger.warning(_KS_WARNING)
+
         if self.context.kill_switch_setting == KillSwitchSetting.OFF:
-            await self.context.kill_switch.enable_ipv6_leak_protection()
-            await self.context.kill_switch.disable()
             if self.context.split_tunneling_setting.enabled:
                 try:
                     await self.context.split_tunneling.set_config(
@@ -312,13 +339,6 @@ class Connected(State):
                     # We decided to treat split tunneling error as non-fatal, to prevent they
                     # impact the core VPN functionality.
                     logger.exception("Error setting split tunnel configuration")
-
-        else:
-            # This is specific to the routing table KS implementation and should be removed.
-            # At this point we switch from the routed KS to the full-on KS.
-            await self.context.kill_switch.enable(
-                permanent=(self.context.kill_switch_setting == KillSwitchSetting.PERMANENT)
-            )
 
         await self.context.connection.add_persistence()
 

--- a/proton/vpn/core/connection.py
+++ b/proton/vpn/core/connection.py
@@ -189,30 +189,39 @@ class VPNConnector:  # pylint: disable=too-many-instance-attributes
         """Enables/disables the kill switch depending on the setting value."""
         kill_switch = self._current_state.context.kill_switch
 
-        if kill_switch_setting == KillSwitchSetting.PERMANENT:
-            await kill_switch.enable(permanent=True)
-            # Since full KS already prevents IPv6 leaks:
-            await kill_switch.disable_ipv6_leak_protection()
-
-        elif kill_switch_setting == KillSwitchSetting.ON:
-            if isinstance(self._current_state, states.Disconnected):
-                await kill_switch.disable()
-                await kill_switch.disable_ipv6_leak_protection()
-            else:
-                await kill_switch.enable(permanent=False)
+        try:
+            if kill_switch_setting == KillSwitchSetting.PERMANENT:
+                await kill_switch.enable(permanent=True)
                 # Since full KS already prevents IPv6 leaks:
                 await kill_switch.disable_ipv6_leak_protection()
 
-        elif kill_switch_setting == KillSwitchSetting.OFF:
-            if isinstance(self._current_state, states.Disconnected):
-                await kill_switch.disable()
-                await kill_switch.disable_ipv6_leak_protection()
-            else:
-                await kill_switch.enable_ipv6_leak_protection()
-                await kill_switch.disable()
+            elif kill_switch_setting == KillSwitchSetting.ON:
+                if isinstance(self._current_state, states.Disconnected):
+                    await kill_switch.disable()
+                    await kill_switch.disable_ipv6_leak_protection()
+                else:
+                    await kill_switch.enable(permanent=False)
+                    # Since full KS already prevents IPv6 leaks:
+                    await kill_switch.disable_ipv6_leak_protection()
 
-        else:
-            raise RuntimeError(f"Unexpected kill switch setting: {kill_switch_setting}")
+            elif kill_switch_setting == KillSwitchSetting.OFF:
+                if isinstance(self._current_state, states.Disconnected):
+                    await kill_switch.disable()
+                    await kill_switch.disable_ipv6_leak_protection()
+                else:
+                    await kill_switch.enable_ipv6_leak_protection()
+                    await kill_switch.disable()
+
+            else:
+                raise RuntimeError(f"Unexpected kill switch setting: {kill_switch_setting}")
+        except RuntimeError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Kill switch operation failed. This is expected on headless "
+                "servers without full NetworkManager/polkit support. "
+                "The VPN connection will proceed without kill switch protection."
+            )
 
     async def _apply_split_tunneling_settings(
             self, st_settings: SplitTunnelingSetting, ks_setting: KillSwitchSetting


### PR DESCRIPTION
  `protonvpn connect` was crashing on my VPS because `states.py` always called kill switch methods that required NetworkManager + polkit privileges, even with killSwitch disabled.                                                                                                                                                                      
   
  **Changes:**                                                                                                                                                                             
  - Skip `kill_switch.enable()` in Connecting state when kill switch setting is OFF
  - Wrap remaining kill switch calls in try/except so failures log a warning instead of crashing 