### PR TITLE
fix: disable DoT during VPN connection

### DIFF
--- a/proton/vpn/backend/networkmanager/protocol/openvpn/openvpn.py
+++ b/proton/vpn/backend/networkmanager/protocol/openvpn/openvpn.py
@@ -235,6 +235,7 @@ class OpenVPN(LinuxNetworkManager, LocalAgentMixin):
         """
         self._set_custom_connection_id()
         self._set_connection_user_owned()
+        self._disable_dns_over_tls()
         self._set_server_certificate_check()
         self._set_dns()
         self._set_vpn_cert_credentials(private_key_passphrase)
@@ -256,6 +257,18 @@ class OpenVPN(LinuxNetworkManager, LocalAgentMixin):
             NM.SETTING_USER_SETTING_NAME,
             getuser(),
             None
+        )
+
+    def _disable_dns_over_tls(self):
+        """Disable DNS-over-TLS for this connection.
+
+        Overrides the global systemd-resolved DNSOverTLS setting so that
+        ProtonVPN's internal DNS server (plain DNS, port 53) is reachable
+        even when the system is configured with DNSOverTLS=yes.
+        """
+        self._connection_settings.set_property(
+            NM.SETTING_CONNECTION_DNS_OVER_TLS,
+            NM.SettingConnectionDnsOverTls.NO
         )
 
     def _set_server_certificate_check(self):

--- a/proton/vpn/backend/networkmanager/protocol/protun/protun.py
+++ b/proton/vpn/backend/networkmanager/protocol/protun/protun.py
@@ -90,6 +90,7 @@ class Protun(LinuxNetworkManager, LocalAgentMixin):
         self._set_interface_name()
         self._set_connection_type()
         self._set_connection_user_owned()
+        self._disable_dns_over_tls()
         self.connection.add_setting(self._connection_settings)
 
         self._set_route()
@@ -119,6 +120,18 @@ class Protun(LinuxNetworkManager, LocalAgentMixin):
             NM.SETTING_USER_SETTING_NAME,
             getuser(),
             None
+        )
+
+    def _disable_dns_over_tls(self):
+        """Disable DNS-over-TLS for this connection.
+
+        Overrides the global systemd-resolved DNSOverTLS setting so that
+        ProtonVPN's internal DNS server (plain DNS, port 53) is reachable
+        even when the system is configured with DNSOverTLS=yes.
+        """
+        self._connection_settings.set_property(
+            NM.SETTING_CONNECTION_DNS_OVER_TLS,
+            NM.SettingConnectionDnsOverTls.NO
         )
 
     def _set_route(self):

--- a/proton/vpn/backend/networkmanager/protocol/wireguard/wireguard.py
+++ b/proton/vpn/backend/networkmanager/protocol/wireguard/wireguard.py
@@ -178,6 +178,7 @@ class Wireguard(LinuxNetworkManager, LocalAgentMixin):
         self._set_interface_name()
         self._set_connection_type()
         self._set_connection_user_owned()
+        self._disable_dns_over_tls()
         self.connection.add_setting(self._connection_settings)
 
         self._set_route()
@@ -207,6 +208,18 @@ class Wireguard(LinuxNetworkManager, LocalAgentMixin):
             NM.SETTING_USER_SETTING_NAME,
             getuser(),
             None
+        )
+
+    def _disable_dns_over_tls(self):
+        """Disable DNS-over-TLS for this connection.
+
+        Overrides the global systemd-resolved DNSOverTLS setting so that
+        ProtonVPN's internal DNS server (plain DNS, port 53) is reachable
+        even when the system is configured with DNSOverTLS=yes.
+        """
+        self._connection_settings.set_property(
+            NM.SETTING_CONNECTION_DNS_OVER_TLS,
+            NM.SettingConnectionDnsOverTls.NO
         )
 
     def _set_route(self):


### PR DESCRIPTION
Fixes https://github.com/ProtonVPN/proton-vpn-gtk-app/issues/79

Disabling it should be fine since DoT is redundant here anyway.