### PR TITLE
fix: make WireGuard killswitch bridge-aware

### DIFF
--- a/proton/vpn/backend/networkmanager/killswitch/wireguard/nmclient.py
+++ b/proton/vpn/backend/networkmanager/killswitch/wireguard/nmclient.py
@@ -214,13 +214,27 @@ class NMClient:
 
         return future_conn_activated
 
+    @staticmethod
+    def _device_is_enslaved(device: "NM.Device") -> bool:
+        ac = device.get_active_connection()
+        rc = ac.get_connection() if ac else None
+        sc = rc.get_setting_connection() if rc else None
+        if sc is None:
+            return False
+        getter = getattr(sc, "get_controller", None) or sc.get_master
+        return bool(getter())
+
     def get_physical_devices(self) -> List[NM.Device]:
-        """Returns all the active ethernet/wifi devices."""
+        """Returns active ethernet/wifi/bridge devices that own their IP config
+        (excludes enslaved devices whose IP config lives on the master)."""
         return [
             device for device in self._nm_client.get_devices() if (
-                device.get_device_type() in (NM.DeviceType.ETHERNET, NM.DeviceType.WIFI)
+                device.get_device_type() in (
+                    NM.DeviceType.ETHERNET, NM.DeviceType.WIFI, NM.DeviceType.BRIDGE
+                )
                 and device.get_state() is NM.DeviceState.ACTIVATED
-                and device.get_active_connection()  # Maybe this is redundant.
+                and device.get_active_connection()
+                and not self._device_is_enslaved(device)
             )
         ]
 
@@ -289,6 +303,11 @@ class NMClient:
 
         connection = active_connection.get_connection()
         config = connection.get_setting_ip4_config()
+        if config is None:
+            raise GatewayNotFoundError(
+                f"Connection {connection.get_id()!r} has no IPv4 setting "
+                "(likely a bridge slave or unconfigured device)."
+            )
 
         config.add_route(
             NM.IPRoute.new(
@@ -309,6 +328,11 @@ class NMClient:
 
         connection = active_connection.get_connection()
         config = connection.get_setting_ip4_config()
+        if config is None:
+            raise GatewayNotFoundError(
+                f"Connection {connection.get_id()!r} has no IPv4 setting "
+                "(likely a bridge slave or unconfigured device)."
+            )
 
         routes_to_remove = []
         for i in range(config.get_num_routes()):


### PR DESCRIPTION
## Summary

On hosts where the primary uplink is a NetworkManager-managed Linux bridge (e.g. `br0` with a NIC enslaved), connecting to a WireGuard server with the killswitch enabled crashes with:

```
AttributeError: 'NoneType' object has no attribute 'get_num_routes'
```

`NMClient.get_physical_devices()` enumerates all `ETHERNET`/`WIFI` devices in `ACTIVATED` state but does not skip slaves of a bridge/bond/team. The slave NIC is `ACTIVATED`, yet its connection profile carries no IPv4 setting — IP config lives on the controller. The killswitch then dereferences a `None` `NMSettingIP4Config`.

This PR makes the killswitch bridge-aware:

- `get_physical_devices()` now also accepts `NM.DeviceType.BRIDGE` and excludes any device whose active connection has a controller. Detection uses `NMSettingConnection.get_controller()` with a fallback to the deprecated `get_master()` for older libnm builds.
- `_add_ipv4_route` and `_remove_ipv4_routes` raise `GatewayNotFoundError` with a descriptive message instead of `AttributeError` when `get_setting_ip4_config()` returns `None` — defense in depth in case a device without IPv4 config still slips through.

No existing behavior changes for hosts whose default route is on a plain ethernet/wifi NIC: such devices are not enslaved and continue to be picked up exactly as before.

## Test plan

- [ ] Unit tests in `tests/.../wireguard/` covering: bridge controller picked up, enslaved NIC skipped, plain ethernet still picked up, `None` IP4 setting raises `GatewayNotFoundError`.
- [x] Manual: connect / disconnect WireGuard with killswitch enabled on a host whose default route lives on `br0` (bridge) with a NIC enslaved — connection succeeds and routes are added/removed against the bridge.
- [ ] Manual: same flow on a plain ethernet host to confirm no regression.